### PR TITLE
UPDATE HOSTBIP DOMAIN NAMES (2024) +biz.ng +plc.ng -edu.scot -sch.so

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13778,13 +13778,13 @@ hoplix.shop
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
 orx.biz
 biz.gl
+biz.ng
 col.ng
 firm.ng
 gen.ng
 ltd.ng
 ngo.ng
-edu.scot
-sch.so
+plc.ng
 
 // HostFly : https://www.ie.ua
 // Submitted by Bohdan Dub <support@hostfly.com.ua>


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
    - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
    - [Letsencrypt](https://letsencrypt.org/docs/rate-limits/)
 
  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

'HostBip' is a 'PDNR' (Private Domain Name Registry), allowing 3rd parties to register domain names in a variety of domain name extensions/suffixes. This pull request adds or updates the entries for a number of domain extensions that we operate, and disclaims a number of domain names we are no longer operating registry services for.

Organization Website: https://dash.hostbip.com/

Reason for PSL Inclusion
====

'HostBip' has an existing section in the 'Public Suffix List', and is updating the section to include additional domain extensions/suffixes in its portfolio and removing edu.scot domain from the list.

This request is seeking to add these to the PSL so the individuals/institutions operating under these suffixes can gain access to services such as Let's Encrypt, Cloudflare and that other third party systems may better be able to identify the level at which the personal/private name has been registered.

Number of users this request is being made to serve: we are expecting to serve over 300 public and private limited liability companies in the Nigerian marketplace.


DNS Verification via dig
=======

```
dig +short TXT _psl.biz.ng
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.plc.ng
"https://github.com/publicsuffix/list/pull/XXXX"
```


Results of Syntax Checker (`make test`)
=========

```
I've run make test, and it reports that all tests pass.
```

